### PR TITLE
カレンダー表示機能の完了 Close #15

### DIFF
--- a/app/assets/stylesheets/calendars.css
+++ b/app/assets/stylesheets/calendars.css
@@ -1,0 +1,37 @@
+.calendar-table {
+  width: 100%;
+  margin: 0 auto;
+  border-collapse: collapse;
+  text-align: center;
+  font-size: 30px;
+}
+
+.calendar-table th,
+.calendar-table td {
+  border: 1px solid #000;
+  width: 14.2%;
+  height: 80px;
+  position: relative;
+  vertical-align: top;
+  padding: 0;
+}
+
+.calendar-table th {
+  background-color: #f7f7f7;
+}
+
+.calendar-day-link {
+  position: absolute;
+  bottom: 4px;
+  right: 8px;
+  text-decoration: none;
+  color: #333;
+  font-weight: bold;
+  font-family: "Helvetica Neue", Helvetica, Arial, "Hiragino Kaku Gothic ProN",
+               "Meiryo", sans-serif;
+}
+
+.calendar-day-link:hover {
+  background-color: #e9ecef;
+  color: #000;
+}

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,4 +1,24 @@
 class CalendarsController < ApplicationController
   def index
+    begin
+      @date = params[:month] ? Date.parse(params[:month]) : Date.today
+    rescue ArgumentError
+      @date = Date.today
+    end
+
+    @date = params[:month]&.to_date || Date.today
+    @first_day = @date.beginning_of_month
+    @last_day  = @date.end_of_month
+    @first_wday = @first_day.wday
+  end
+
+  def show
+    @date = Date.parse(params[:date])
+
+    record = StudyRecord.find_by(user: current_user, date: @date)
+
+    @accuracy = record&.accuracy
+    @score    = record&.estimated_score
   end
 end
+

--- a/app/models/study_record.rb
+++ b/app/models/study_record.rb
@@ -1,0 +1,3 @@
+class StudyRecord < ApplicationRecord
+  belongs_to :user
+end

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,3 +1,32 @@
-<h1>カレンダー</h1>
-<p>カレンダーを次回公開予定です。</p>
+<h1><%= @date.strftime('%Y年%m月') %></h1>
+
+<!-- 月送り -->
+<div style="margin-bottom: 16px;">
+  <%= link_to "前の月", calendars_path(month: @date.prev_month), class: "btn btn-secondary" %>
+  <%= link_to "次の月", calendars_path(month: @date.next_month), class: "btn btn-secondary" %>
+</div>
+
+<table class="calendar-table">
+  <tr>
+    <% ['日','月','火','水','木','金','土'].each_with_index do |d,i| %>
+      <th style="<%= 'color:red;' if i == 0 %><%= 'color:blue;' if i == 6 %>"><%= d %></th>
+    <% end %>
+  </tr>
+
+  <% @first_wday.times { %>
+  <td style="border:1px solid #000;"></td>
+  <% } %>
+
+  <% (1..@last_day_num).each do |day| %>
+    <% current_date = Date.new(@date.year, @date.month, day) rescue nil %>
+    <% next unless current_date %>
+
+    <td style="border:1px solid #000; position: relative;">
+      <%= link_to day, calendar_day_path(date: current_date), class: "calendar-day-link" %>
+    </td>
+    <% if current_date.saturday? %></tr><tr><% end %>
+  <% end %>
+</table>
+
+<br>
 <%= link_to "メイン画面へ戻る", main_path, class: "btn btn-primary" %>

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -1,0 +1,7 @@
+<h1><%= @date.strftime('%Y年%m月%d日') %> の記録</h1>
+
+<p>正答率：<%= @accuracy.present? ? "#{@accuracy}%" : "記録なし" %></p>
+<p>予想スコア：<%= @score.present? ? "#{@score}点" : "記録なし" %></p>
+
+<br>
+<%= link_to "カレンダーへ戻る", calendars_path, class: "btn btn-secondary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'calendars/index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -22,7 +21,6 @@ Rails.application.routes.draw do
   end
 
   resources :password_resets, only: %i[new create edit update]
-  resources :calendars, only: [:index]
   get 'login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
@@ -48,6 +46,8 @@ Rails.application.routes.draw do
   patch 'settings/level', to: 'settings#update_level'
   get 'settings/notification', to: 'settings#notification', as: 'settings_notification'
   get 'settings/account', to: 'settings#account', as: 'settings_account'
+  get '/calendars', to: 'calendars#index', as: 'calendars'
+  get '/calendars/:date', to: 'calendars#show', as: 'calendar_day'
 
   namespace :admin do
     root to: "main#index"

--- a/db/migrate/20251112092442_create_study_records.rb
+++ b/db/migrate/20251112092442_create_study_records.rb
@@ -1,0 +1,12 @@
+class CreateStudyRecords < ActiveRecord::Migration[7.1]
+  def change
+    create_table :study_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :date
+      t.integer :accuracy
+      t.integer :estimated_score
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_08_104639) do
+ActiveRecord::Schema[7.1].define(version: 2025_11_12_092442) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_08_104639) do
     t.datetime "updated_at", null: false
     t.json "content"
     t.string "kind"
+  end
+
+  create_table "study_records", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "date"
+    t.integer "accuracy"
+    t.integer "estimated_score"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_study_records_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -41,4 +51,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_08_104639) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "study_records", "users"
 end

--- a/test/fixtures/study_records.yml
+++ b/test/fixtures/study_records.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  date: 2025-11-12
+  accuracy: 1
+  estimated_score: 1
+
+two:
+  user: two
+  date: 2025-11-12
+  accuracy: 1
+  estimated_score: 1

--- a/test/models/study_record_test.rb
+++ b/test/models/study_record_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StudyRecordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
カレンダー画面にカレンダーが表示されるようにしました。
曜日の文字を平日→黒色・土曜日→青・日曜日→赤としました。
罫線の入った表の形式としました。
日付のリンクを押すとその日の学習時間と正答率が表示されるようにしました。